### PR TITLE
Automatically detect if running interactively.

### DIFF
--- a/physcraper/__init__.py
+++ b/physcraper/__init__.py
@@ -126,9 +126,12 @@ class ConfigObj(object):
               * self.ncbi_parser_names_fn: path to 'names.dmp' file, that contains the different ID's
     """
 
-    def __init__(self, configfi, interactive=True):
+    def __init__(self, configfi, interactive=None):
         if _DEBUG:
             sys.stdout.write("Building config object\n")
+
+        if interactive is None:
+            interactive=sys.stdin.isatty()
         debug(configfi)
         debug(os.path.isfile(configfi))
         assert os.path.isfile(configfi)


### PR DESCRIPTION
With this, creating a config object should automatically be interactive
when run by the user explicitly and bot ask for input is running as a
batch job.

If a value is passed explicitly we don't try to guess.