### PR TITLE
Set error code when existing prematurely from program.

### DIFF
--- a/physcraper/__init__.py
+++ b/physcraper/__init__.py
@@ -286,7 +286,7 @@ def get_dataset_from_treebase(study_id,
     treebase_url = nexson['nexml'][u'^ot:dataDeposit'][u'@href']
     if 'treebase' not in nexson['nexml'][u'^ot:dataDeposit'][u'@href']:
         sys.stderr.write("No treebase record associated with study ")
-        sys.exit()
+        sys.exit(-2)
     else:
         tb_id = treebase_url.split(':S')[1]
         url = "https://treebase.org/treebase-web/search/downloadAStudy.html?id={}&format=nexus".format(tb_id)
@@ -1040,7 +1040,7 @@ def get_mrca_ott(ott_ids):
     if len(synth_tree_ott_ids) == 0:
         sys.stderr.write('No sampled taxa were found in the current synthetic tree. '
                          'Please find and input and appropriate OTT id as ingroup mrca in generate_ATT_from_files')
-        sys.exit()
+        sys.exit(-3)
     mrca_node = tree_of_life.mrca(ott_ids=synth_tree_ott_ids, wrap_response=False)  # need to fix wrap eventually
     if u'nearest_taxon' in mrca_node.keys():
         tax_id = mrca_node[u'nearest_taxon'].get(u'ott_id')
@@ -1054,7 +1054,7 @@ def get_mrca_ott(ott_ids):
         # debug(mrca_node.keys())
         sys.stderr.write('(v3) MRCA of sampled taxa not found. Please find and input an '
                          'appropriate OTT id as ingroup mrca in generate_ATT_from_files')
-        sys.exit()
+        sys.exit(-4)
     return tax_id
 
 
@@ -2115,7 +2115,7 @@ class PhyscraperScrape(object):  # TODO do I want to be able to instantiate this
         except OSError as e:
             if e.errno == os.errno.ENOENT:
                 sys.stderr.write("failed running papara. Is it installed?\n")
-                sys.exit()
+                sys.exit(-5)
             # handle file not found error.
             else:
                 # Something else went wrong while trying to run `wget`
@@ -2171,7 +2171,7 @@ class PhyscraperScrape(object):  # TODO do I want to be able to instantiate this
             except OSError as e:
                 if e.errno == os.errno.ENOENT:
                     sys.stderr.write("failed running raxmlHPC. Is it installed?")
-                    sys.exit()
+                    sys.exit(-6)
                 # handle file not
                 # handle file not found error.
                 else:

--- a/tests/test_addLocal.py
+++ b/tests/test_addLocal.py
@@ -37,7 +37,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest setup failed\n\n")
-    sys.exit()
+    sys.exit(-1)
 
 if not os.path.exists("{}".format(workdir)):
     os.makedirs("{}".format(workdir))

--- a/tests/test_add_all.py
+++ b/tests/test_add_all.py
@@ -19,7 +19,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape = FilterBlast(data_obj, ids)
 filteredScrape._blasted = 1
 filteredScrape.read_blast_wrapper(blast_dir="tests/data/precooked/fixed/tte_blast_files")

--- a/tests/test_blacklist.py
+++ b/tests/test_blacklist.py
@@ -24,7 +24,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 noblackScrape = FilterBlast(data_obj, ids)
 noblackScrape._blasted = 1
 src = "tests/data/precooked/fixed/tte_blast_files"
@@ -52,7 +52,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-2)
 filteredScrape = FilterBlast(data_obj, ids)
 filteredScrape.blacklist = blacklist
 filteredScrape._blasted = 1

--- a/tests/test_calc_mean_sd.py
+++ b/tests/test_calc_mean_sd.py
@@ -22,7 +22,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape = physcraper.FilterBlast(data_obj, ids)
 
 # test begins

--- a/tests/test_loop_for_blast.py
+++ b/tests/test_loop_for_blast.py
@@ -23,7 +23,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape = FilterBlast(data_obj, ids)
 filteredScrape.add_setting_to_self(downtorank, threshold)
 # filteredScrape.acc_list_mrca = pickle.load(open("tests/data/precooked/acc_list_mrca.p", 'rb'))

--- a/tests/test_read_local_blast.py
+++ b/tests/test_read_local_blast.py
@@ -25,7 +25,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape = physcraper.FilterBlast(data_obj, ids)
 filteredScrape._blasted = 1
 blast_dir = "tests/data/precooked/fixed/tte_blast_files"

--- a/tests/test_remove_id_seq.py
+++ b/tests/test_remove_id_seq.py
@@ -19,7 +19,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape =  FilterBlast(data_obj, ids)
 filteredScrape._blasted = 1
 

--- a/tests/test_remove_identical_seqs.py
+++ b/tests/test_remove_identical_seqs.py
@@ -22,7 +22,7 @@ try:
 except:
     sys.stderr.write("run 'python tests/testfilesetup.py' to setup data files for tests. EXITING")
     sys.stdout.write("\n\nTest `remove_identical_seqs' FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 
 print("start")
 scraper = PhyscraperScrape(data_obj, ids)

--- a/tests/test_remove_taxa_aln_tre.py
+++ b/tests/test_remove_taxa_aln_tre.py
@@ -18,7 +18,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape =  FilterBlast(data_obj, ids)
 
 len_aln_before = len(filteredScrape.data.aln.as_string('phylip'))

--- a/tests/test_run_local_blast.py
+++ b/tests/test_run_local_blast.py
@@ -22,7 +22,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape =  physcraper.FilterBlast(data_obj, ids)
 
 blast_db = "otuSlagascanus"

--- a/tests/test_select_seq_by_local_blast.py
+++ b/tests/test_select_seq_by_local_blast.py
@@ -27,7 +27,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 
 filteredScrape =  physcraper.FilterBlast(data_obj, ids)
 filteredScrape.add_setting_to_self(downtorank, threshold)

--- a/tests/test_sp_d.py
+++ b/tests/test_sp_d.py
@@ -21,7 +21,7 @@ try:
 except:
     # sys.stderr.write("run 'python tests/testfilesetup.py' to setup data files for tests. EXITING")
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape =  FilterBlast(data_obj, ids)
 
 

--- a/tests/test_sp_seq_d.py
+++ b/tests/test_sp_seq_d.py
@@ -23,7 +23,7 @@ try:
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape =  FilterBlast(data_obj, ids)
 
 

--- a/tests/tests_write_blast.py
+++ b/tests/tests_write_blast.py
@@ -27,7 +27,7 @@ try:
 
 except:
     sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
+    sys.exit(-1)
 filteredScrape = FilterBlast(data_obj, ids)
 filteredScrape._blasted = 1
 blast_dir = "tests/data/precooked/fixed/tte_blast_files"


### PR DESCRIPTION
The unix convention is to return with a non-zero error-code when
something was wrong, with the value of the error code which depends on
the reason for exist.

Especially in unit-test framework, the return code is critical.
This also affect the behavior of shells, like && and || in bash.

Hence assign an error code to some of the sys.exit

Note that in python you can also pass a string to sys.exit(...) and that
python will by itself return a non-zero error code, as well as print a
message.