### PR TITLE
Move some of the testing to pytest.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -21,4 +21,4 @@ zope.interface==4.4.1
 numpy==1.14.5
 ete2==2.3.10
 pandas==0.23.4
-concat
+pytest

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -2,7 +2,7 @@ if [ -f output/owndata/ ]; then echo 'Found some!'; fi
 
 python tests/test_remove_identical_seqs.py
 python tests/test_fromfile.py
-python tests/test_configread.py
+py.test tests/test_configread.py
 python tests/test_species_translation.py
 python tests/test_write_labelled.py
 python tests/test_add_all.py
@@ -11,7 +11,7 @@ python tests/test_prune_short.py
 python tests/test_remove_taxa_aln_tre.py
 python tests/test_run_local_blast.py
 python tests/test_sp_d.py
-python tests/test_sp_seq_d.py
+py.test tests/test_sp_seq_d.py
 python tests/test_select_seq_by_local_blast.py
 python tests/test_calc_mean_sd.py
 python tests/test_read_local_blast.py

--- a/tests/test_configread.py
+++ b/tests/test_configread.py
@@ -1,16 +1,12 @@
+from __future__ import print_function, absolute_import 
 
-import sys
-from physcraper import ConfigObj
 
 expected_keys = ['seq_len_perc', 'num_threads', 'phylesystem_loc', 'blast_loc', 'gifilename', 'get_ncbi_taxonomy', 'hitlist_size', 'id_pickle', 'ott_ncbi', 'url_base', 'ncbi_dmp', 'email', 'e_value_thresh', 'blastdb']
 
-sys.stdout.write("\nTesting configuration object contents\n")
-try:
+def test_config():
+    from physcraper import ConfigObj
     configfi = "tests/data/localblast.config"
-    conf = ConfigObj(configfi, interactive = False)
+    conf = ConfigObj(configfi, interactive=False)
     assert conf.email == 'ejmctavish@gmail.com'
     assert conf.url_base == None
     assert conf.__dict__.keys() == expected_keys
-    sys.stdout.write("\nTest configread.py passed\n")
-except:
-  sys.stdout.write("\nTest configread.py FAILED (expected, test in progress)\n")

--- a/tests/test_sp_seq_d.py
+++ b/tests/test_sp_seq_d.py
@@ -1,3 +1,5 @@
+from __future__ import print_function, absolute_import
+
 import sys
 import os
 from physcraper import ConfigObj, IdDicts, FilterBlast
@@ -13,29 +15,26 @@ treshold = 2
 selectby = "blast"
 downtorank = None
 
+def test_sp_seq_d():
 
-absworkdir = os.path.abspath(workdir)
-try:
+
+    absworkdir = os.path.abspath(workdir)
     conf = ConfigObj(configfi, interactive=False)
     data_obj = pickle.load(open("tests/data/precooked/tiny_dataobj.p", 'rb'))
     data_obj.workdir = absworkdir
     ids = IdDicts(conf, workdir=data_obj.workdir)
     ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/tiny_acc_map.p", "rb"))
-except:
-    sys.stdout.write("\n\nTest FAILED\n\n")
-    sys.exit()
-filteredScrape =  FilterBlast(data_obj, ids)
+    filteredScrape =  FilterBlast(data_obj, ids)
 
 
-filteredScrape._blasted = 1
-blast_dir = "tests/data/precooked/fixed/tte_blast_files"
-# filteredScrape.acc_list_mrca = pickle.load(open("tests/data/precooked/acc_list_mrca.p", 'rb'))
-filteredScrape.read_blast_wrapper(blast_dir=blast_dir)
-filteredScrape.remove_identical_seqs()
-filteredScrape.sp_dict(downtorank)
-filteredScrape.seq_filter = ['deleted', 'subsequence,', 'not', "removed", "deleted,"]
+    filteredScrape._blasted = 1
+    blast_dir = "tests/data/precooked/fixed/tte_blast_files"
+    # filteredScrape.acc_list_mrca = pickle.load(open("tests/data/precooked/acc_list_mrca.p", 'rb'))
+    filteredScrape.read_blast_wrapper(blast_dir=blast_dir)
+    filteredScrape.remove_identical_seqs()
+    filteredScrape.sp_dict(downtorank)
+    filteredScrape.seq_filter = ['deleted', 'subsequence,', 'not', "removed", "deleted,"]
 
-try:
     gi_sp_d = []
     for key in filteredScrape.sp_d:
         v = filteredScrape.sp_d[key]  
@@ -71,7 +70,3 @@ try:
     assert len(ott_sp_seq_d) == len(user_sp_d)
     assert len(gi_sp_seq_d) == len(gi_sp_d)
     # print("The length of the gi and user input names in sp_d and sp_seq_dict are the same")
-    sys.stdout.write("\ntest passed\n")
-except:
-    # print("FAILED:test sp_seq d not working!")
-    sys.stderr.write("\ntest failed\n")


### PR DESCRIPTION
pytest has many advantages over creating your own test framework.
 1) it has color: Green OK, Red when failling.
 2) it will automatically show you individual error with parameters, so
 you do not have to re-run things. Example:

         def test_config():
            from physcraper import ConfigObj
            configfi = "tests/data/localblast.config"
            conf = ConfigObj(configfi, interactive=False)
    >       assert conf.email == 'ejmctavish@gmail.com'
    E       AssertionError: assert 'bussonniermatthias@gmail.com' == 'ejmctavish@gmail.com'
    E         - bussonniermatthias@gmail.com
    E         + ejmctavish@gmail.com

 3) when all test are py-testified, it can auto-discover test.
 4) it has options like --lf (last failed) and --ff (failed first). That
 speed-up iterative development.
 5) it shows warning for things you should pay attention to but are not
 yet errors:

     tests/test_configread.py::test_config
      /Users/mbussonnier/dev/physcraper/physcraper/__init__.py:143: DeprecationWarning: You passed a bytestring as `filenames`. This will not work on Python 3. Use `cp.read_file()` or switch to using Unicode strings across the board.
        config.read(configfi)

As you will see it also simplify testign quite a bit as it takes care of
the try/except by itself as well. And in general the less you have to
write, the easier it is.