### PR TITLE
indent issue

### DIFF
--- a/physcraper/__init__.py
+++ b/physcraper/__init__.py
@@ -1766,7 +1766,7 @@ class PhyscraperScrape(object):
                 for hsp in alignment.hsps:
                     if float(hsp.expect) < float(self.config.e_value_thresh):
                         if local_id not in self.data.gb_dict:  # skip ones we already have
-                        local_id = alignment.title.split("|")[-1].split(" ")[-1]
+                            local_id = alignment.title.split("|")[-1].split(" ")[-1]
                             unpbl_local_id = "unpubl_{}".format(local_id)
                             self.new_seqs[unpbl_local_id] = hsp.sbjct
                             self.data.gb_dict[unpbl_local_id] = {'title': "unpublished", 'localID': local_id}


### PR DESCRIPTION
Most test are passing except for a few attribute error; `run_blast_wrapper` seem to not be defined. 



```
self = <physcraper.FilterBlast object at 0x10d7e7150>, blast_dir = 'tests/data/precooked/fixed/tte_blast_files'

    def read_blast_wrapper(self, blast_dir=None):
        """reads in and processes the blast xml files

        :param blast_dir: path to directory which contains blast files
        :return: fills different dictionaries with information from blast files
        """
        debug("read_blast_wrapper")
        if blast_dir:
            if _VERBOSE:
                sys.stdout.write("blast dir is {}\n".format(blast_dir))
            self.blast_subdir = os.path.abspath(blast_dir)
        else:
            if _VERBOSE:
                sys.stdout.write("blast dir is {}\n".format(self.blast_subdir))
            if not os.path.exists(self.blast_subdir):
                os.mkdir(self.blast_subdir)
        if self.unpublished:
            self.read_unpublished_blast_query()
        else:
            if not self._blasted:
>               self.run_blast_wrapper()
E               AttributeError: 'FilterBlast' object has no attribute 'run_blast_wrapper'

physcraper/__init__.py:1829: AttributeError
```