### PR TITLE
Basic travis setup. 

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,10 @@
+language: python
+python:
+  - "2.7"
+# command to install dependencies
+install:
+  - pip install -r requirements.txt
+  - pip install . 
+# command to run tests
+script:
+  - py.test tests/ --setup-only

--- a/tests/concatsetup.py
+++ b/tests/concatsetup.py
@@ -4,77 +4,78 @@ import json
 from physcraper import wrappers, OtuJsonDict, ConfigObj, IdDicts
 #
 
+def test():
 
-# tiny its
-seqaln = "tests/data/tiny_comb_its/tiny_comb_its.fasta"
-mattype = "fasta"
-trfn = "tests/data/tiny_comb_its/tiny_comb_its.tre"
-schema_trf = "newick"
-id_to_spn = r"tests/data/tiny_comb_its/nicespl.csv"
-workdir = "tests/data/tiny_comb_its"
-configfi = "tests/data/test.config"
-otu_jsonfi = "{}/otu_dict.json".format(workdir)
-threshold = 2
-selectby = "blast"
+    # tiny its
+    seqaln = "tests/data/tiny_comb_its/tiny_comb_its.fasta"
+    mattype = "fasta"
+    trfn = "tests/data/tiny_comb_its/tiny_comb_its.tre"
+    schema_trf = "newick"
+    id_to_spn = r"tests/data/tiny_comb_its/nicespl.csv"
+    workdir = "tests/data/tiny_comb_its"
+    configfi = "tests/data/test.config"
+    otu_jsonfi = "{}/otu_dict.json".format(workdir)
+    threshold = 2
+    selectby = "blast"
 
-if not os.path.exists("{}".format(workdir)):
-    os.makedirs("{}".format(workdir))
-
-conf = ConfigObj(configfi)
-ids = IdDicts(conf, workdir=workdir)
-
-
-if os.path.exists(otu_jsonfi):
-    print("load json")
-    otu_json = json.load(open(otu_jsonfi))
-else:
-    otu_json = OtuJsonDict(id_to_spn, ids)
-    json.dump(otu_json, open(otu_jsonfi, "w"))
-
-
-wrappers.filter_data_run(seqaln,
-                         mattype,
-                         trfn,
-                         schema_trf,
-                         workdir,
-                         threshold,
-                         otu_jsonfi,
-                         configfi,
-                         selectby=selectby)
-
-
-# tiny ets
-seqaln = "tests/data/tiny_comb_ets/tiny_comb_ets.fasta"
-mattype = "fasta"
-trfn = "tests/data/tiny_comb_ets/tiny_comb_ets.tre"
-schema_trf = "newick"
-id_to_spn = r"tests/data/tiny_comb_ets/nicespl.csv"
-
-workdir = "tests/data/tiny_comb_ets"
-configfi = "tests/data/test.config"
-otu_jsonfi = "{}/otu_dict.json".format(workdir)
-treshold = 2
-selectby = "blast"
-
-if not os.path.exists("{}".format(workdir)):
+    if not os.path.exists("{}".format(workdir)):
         os.makedirs("{}".format(workdir))
 
-conf = ConfigObj(configfi)
-ids = IdDicts(conf, workdir=workdir)
+    conf = ConfigObj(configfi)
+    ids = IdDicts(conf, workdir=workdir)
 
-if os.path.exists(otu_jsonfi):
-    print("load json")
-    otu_json = json.load(open(otu_jsonfi))
-else:
-    otu_json = OtuJsonDict(id_to_spn, ids)
-    json.dump(otu_json, open(otu_jsonfi, "w"))
 
-wrappers.filter_data_run(seqaln,
-                         mattype,
-                         trfn,
-                         schema_trf,
-                         workdir,
-                         threshold,
-                         otu_jsonfi,
-                         configfi,
-                         selectby=selectby)
+    if os.path.exists(otu_jsonfi):
+        print("load json")
+        otu_json = json.load(open(otu_jsonfi))
+    else:
+        otu_json = OtuJsonDict(id_to_spn, ids)
+        json.dump(otu_json, open(otu_jsonfi, "w"))
+
+
+    wrappers.filter_data_run(seqaln,
+                             mattype,
+                             trfn,
+                             schema_trf,
+                             workdir,
+                             threshold,
+                             otu_jsonfi,
+                             configfi,
+                             selectby=selectby)
+
+
+    # tiny ets
+    seqaln = "tests/data/tiny_comb_ets/tiny_comb_ets.fasta"
+    mattype = "fasta"
+    trfn = "tests/data/tiny_comb_ets/tiny_comb_ets.tre"
+    schema_trf = "newick"
+    id_to_spn = r"tests/data/tiny_comb_ets/nicespl.csv"
+
+    workdir = "tests/data/tiny_comb_ets"
+    configfi = "tests/data/test.config"
+    otu_jsonfi = "{}/otu_dict.json".format(workdir)
+    treshold = 2
+    selectby = "blast"
+
+    if not os.path.exists("{}".format(workdir)):
+            os.makedirs("{}".format(workdir))
+
+    conf = ConfigObj(configfi)
+    ids = IdDicts(conf, workdir=workdir)
+
+    if os.path.exists(otu_jsonfi):
+        print("load json")
+        otu_json = json.load(open(otu_jsonfi))
+    else:
+        otu_json = OtuJsonDict(id_to_spn, ids)
+        json.dump(otu_json, open(otu_jsonfi, "w"))
+
+    wrappers.filter_data_run(seqaln,
+                             mattype,
+                             trfn,
+                             schema_trf,
+                             workdir,
+                             threshold,
+                             otu_jsonfi,
+                             configfi,
+                             selectby=selectby)

--- a/tests/filter_OToL.py
+++ b/tests/filter_OToL.py
@@ -2,24 +2,26 @@ import os
 import json
 from physcraper import wrappers, OtuJsonDict
 
-# Use OpenTree phylesystem identifiers to get study and tree
-study_id = "pg_873"
-tree_id = "tree1679"
-seqaln = "tests/data/minitest.fas"
-mattype = "fasta"
-workdir = "tests/output/opentree"
-configfi = "example.config"
 
-threshold = 2
-selectby = "blast"
-downtorank = "species"
+def test():
+    # Use OpenTree phylesystem identifiers to get study and tree
+    study_id = "pg_873"
+    tree_id = "tree1679"
+    seqaln = "tests/data/minitest.fas"
+    mattype = "fasta"
+    workdir = "tests/output/opentree"
+    configfi = "example.config"
 
-# select a wrapper function, depending on what you want to do, see short tutorial:
-wrappers.filter_OTOL(study_id,
-                     tree_id,
-                     seqaln,
-                     mattype,
-                     configfi,
-                     threshold,
-                     selectby=selectby,
-                     downtorank=downtorank)
+    threshold = 2
+    selectby = "blast"
+    downtorank = "species"
+
+    # select a wrapper function, depending on what you want to do, see short tutorial:
+    wrappers.filter_OTOL(study_id,
+                         tree_id,
+                         seqaln,
+                         mattype,
+                         configfi,
+                         threshold,
+                         selectby=selectby,
+                         downtorank=downtorank)

--- a/tests/filter_blast.py
+++ b/tests/filter_blast.py
@@ -4,32 +4,33 @@ import json
 from physcraper import wrappers
 #
 
-seqaln = "tests/data/tiny_test_example/test.fas"
-mattype = "fasta"
-trfn = "tests/data/tiny_test_example/test.tre"
-schema_trf = "newick"
-workdir = "test_filter"
-configfi = "tests/data/blubb_localblast.config"
-id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
-otu_jsonfi = "{}/otu_dict.json".format(workdir)
-threshold = 2
-selectby = "blast"
+def test():
+    seqaln = "tests/data/tiny_test_example/test.fas"
+    mattype = "fasta"
+    trfn = "tests/data/tiny_test_example/test.tre"
+    schema_trf = "newick"
+    workdir = "test_filter"
+    configfi = "tests/data/blubb_localblast.config"
+    id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
+    otu_jsonfi = "{}/otu_dict.json".format(workdir)
+    threshold = 2
+    selectby = "blast"
 
-if os.path.exists(otu_jsonfi):
-    otu_json = json.load(open(otu_jsonfi))
-else:
-    otu_json = wrappers.OtuJsonDict(id_to_spn, configfi)
-    if not os.path.exists(workdir):
-        os.mkdir(workdir)
-    json.dump(otu_json, open(otu_jsonfi, "w"))
+    if os.path.exists(otu_jsonfi):
+        otu_json = json.load(open(otu_jsonfi))
+    else:
+        otu_json = wrappers.OtuJsonDict(id_to_spn, configfi)
+        if not os.path.exists(workdir):
+            os.mkdir(workdir)
+        json.dump(otu_json, open(otu_jsonfi, "w"))
 
 
-wrappers.filter_data_run(seqaln,
-                         mattype,
-                         trfn,
-                         schema_trf,
-                         workdir,
-                         threshold,
-                         otu_jsonfi,
-                         configfi,
-                         selectby=selectby)
+    wrappers.filter_data_run(seqaln,
+                             mattype,
+                             trfn,
+                             schema_trf,
+                             workdir,
+                             threshold,
+                             otu_jsonfi,
+                             configfi,
+                             selectby=selectby)

--- a/tests/impl_concat.py
+++ b/tests/impl_concat.py
@@ -7,19 +7,21 @@ from physcraper import wrappers, generate_ATT_from_files, AlignTreeTax, debug
 from dendropy import DnaCharacterMatrix
 from copy import deepcopy
 
+def test():
 
-workdir_its = "./runs/tiny_comb_its"
-workdir_ets = "./runs/tiny_comb_ets"
-workdir_3 = "./runs/tiny_comb_ets"
-email = "martha.kandziora@yahoo.com"
-percentage = 0.4
 
-pickle_fn = "scrape_checkpoint.p"
+    workdir_its = "./runs/tiny_comb_its"
+    workdir_ets = "./runs/tiny_comb_ets"
+    workdir_3 = "./runs/tiny_comb_ets"
+    email = "martha.kandziora@yahoo.com"
+    percentage = 0.4
 
-workdir_comb = "./tests/output/impl_concat"
-genelist = {"its": {"workdir": workdir_its, "pickle": pickle_fn}, 
-            "ets": {"workdir": workdir_ets, "pickle": pickle_fn}
-            }
+    pickle_fn = "scrape_checkpoint.p"
 
-conc = wrappers.concat(genelistdict=genelist, workdir_comb=workdir_comb,
-                       email=email, percentage=percentage, user_concat_fn=None)
+    workdir_comb = "./tests/output/impl_concat"
+    genelist = {"its": {"workdir": workdir_its, "pickle": pickle_fn}, 
+                "ets": {"workdir": workdir_ets, "pickle": pickle_fn}
+                }
+
+    conc = wrappers.concat(genelistdict=genelist, workdir_comb=workdir_comb,
+                           email=email, percentage=percentage, user_concat_fn=None)

--- a/tests/own_data_scrape_local.py
+++ b/tests/own_data_scrape_local.py
@@ -3,33 +3,35 @@ import os
 import json
 from physcraper import wrappers, OtuJsonDict, ConfigObj, IdDicts
 
-seqaln = "tests/data/tiny_test_example/test.fas"
-mattype = "fasta"
-trfn = "tests/data/tiny_test_example/test.tre"
-schema_trf = "newick"
-workdir = "tests/output/test_own_local"
-configfi = "tests/data/test.config"
-# configfi = "tests/data/aws.config"
-id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
-otu_jsonfi = "{}/otu_dict.json".format(workdir)
+def test():
+
+    seqaln = "tests/data/tiny_test_example/test.fas"
+    mattype = "fasta"
+    trfn = "tests/data/tiny_test_example/test.tre"
+    schema_trf = "newick"
+    workdir = "tests/output/test_own_local"
+    configfi = "tests/data/test.config"
+    # configfi = "tests/data/aws.config"
+    id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
+    otu_jsonfi = "{}/otu_dict.json".format(workdir)
 
 
-if not os.path.exists("{}".format(workdir)):
-    os.makedirs("{}".format(workdir))
+    if not os.path.exists("{}".format(workdir)):
+        os.makedirs("{}".format(workdir))
 
-conf = ConfigObj(configfi)
-ids = IdDicts(conf, workdir=workdir)
+    conf = ConfigObj(configfi)
+    ids = IdDicts(conf, workdir=workdir)
 
-if os.path.exists(otu_jsonfi):
-    print("load json")
-else:
-    otu_json = OtuJsonDict(id_to_spn, ids)
-    json.dump(otu_json, open(otu_jsonfi, "w"))
+    if os.path.exists(otu_jsonfi):
+        print("load json")
+    else:
+        otu_json = OtuJsonDict(id_to_spn, ids)
+        json.dump(otu_json, open(otu_jsonfi, "w"))
 
-wrappers.own_data_run(seqaln,
-                      mattype,
-                      trfn,
-                      schema_trf,
-                      workdir,
-                      otu_jsonfi,
-                      configfi)
+    wrappers.own_data_run(seqaln,
+                          mattype,
+                          trfn,
+                          schema_trf,
+                          workdir,
+                          otu_jsonfi,
+                          configfi)

--- a/tests/own_data_scrape_ncbi.py
+++ b/tests/own_data_scrape_ncbi.py
@@ -3,34 +3,36 @@ import os
 import json
 from physcraper import wrappers, OtuJsonDict, ConfigObj, IdDicts
 
-seqaln = "tests/data/tiny_test_example/test.fas"
-mattype = "fasta"
-trfn = "tests/data/tiny_test_example/test.tre"
-schema_trf = "newick"
-workdir = "tests/output/test_ncbi_blast"
-configfi = "tests/data/test.config"
-# configfi = "tests/data/aws.config"
-id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
-otu_jsonfi = "{}/otu_dict.json".format(workdir)
+def test():
 
-if not os.path.exists("{}".format(workdir)):
-        os.makedirs("{}".format(workdir))
+    seqaln = "tests/data/tiny_test_example/test.fas"
+    mattype = "fasta"
+    trfn = "tests/data/tiny_test_example/test.tre"
+    schema_trf = "newick"
+    workdir = "tests/output/test_ncbi_blast"
+    configfi = "tests/data/test.config"
+    # configfi = "tests/data/aws.config"
+    id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
+    otu_jsonfi = "{}/otu_dict.json".format(workdir)
 
-conf = ConfigObj(configfi)
-ids = IdDicts(conf, workdir=workdir)
+    if not os.path.exists("{}".format(workdir)):
+            os.makedirs("{}".format(workdir))
+
+    conf = ConfigObj(configfi)
+    ids = IdDicts(conf, workdir=workdir)
 
 
-if os.path.exists(otu_jsonfi):
-    print("load json")
-    otu_json = json.load(open(otu_jsonfi))
-else:
-    otu_json = OtuJsonDict(id_to_spn, ids)
-    json.dump(otu_json, open(otu_jsonfi, "w"))
+    if os.path.exists(otu_jsonfi):
+        print("load json")
+        otu_json = json.load(open(otu_jsonfi))
+    else:
+        otu_json = OtuJsonDict(id_to_spn, ids)
+        json.dump(otu_json, open(otu_jsonfi, "w"))
 
-wrappers.own_data_run(seqaln,
-                      mattype,
-                      trfn,
-                      schema_trf,
-                      workdir,
-                      otu_jsonfi,
-                      configfi)
+    wrappers.own_data_run(seqaln,
+                          mattype,
+                          trfn,
+                          schema_trf,
+                          workdir,
+                          otu_jsonfi,
+                          configfi)

--- a/tests/test_concat_make_concat_id.py
+++ b/tests/test_concat_make_concat_id.py
@@ -14,34 +14,28 @@ genelist = {"its": {"workdir": workdir_its, "pickle": pickle_fn},
 
 sys.stdout.write("\ntests Concat func make_concat_id_dict\n")
 
+def test():
 
-concat = Concat(workdir_comb, email)
-for item in genelist.keys():
-    concat.load_single_genes(genelist[item]['workdir'], genelist[item]["pickle"], item)
+    concat = Concat(workdir_comb, email)
+    for item in genelist.keys():
+        concat.load_single_genes(genelist[item]['workdir'], genelist[item]["pickle"], item)
 
-concat.combine()
-spnl = []
-for genename in concat.single_runs:
-    for otu in concat.single_runs[genename].data.otu_dict.keys():
-        data = concat.single_runs[genename].data.otu_dict[otu]
-       
-        if '^ot:ottTaxonName' in data:
-            spn = concat.get_taxon_info('^ot:ottTaxonName', data)
-        elif '^user:TaxonName' in data:
-            spn = concat.get_taxon_info('^user:TaxonName', data)
-        spnl.append(spn)
+    concat.combine()
+    spnl = []
+    for genename in concat.single_runs:
+        for otu in concat.single_runs[genename].data.otu_dict.keys():
+            data = concat.single_runs[genename].data.otu_dict[otu]
+           
+            if '^ot:ottTaxonName' in data:
+                spn = concat.get_taxon_info('^ot:ottTaxonName', data)
+            elif '^user:TaxonName' in data:
+                spn = concat.get_taxon_info('^user:TaxonName', data)
+            spnl.append(spn)
 
-len_single = len(set(spnl))
-# print(set(spnl))
-# print(concat.sp_acc_comb)
-len_concat_id_dict = len(concat.sp_acc_comb)
-
-
-# print(len_single, len_concat_id_dict)
+    len_single = len(set(spnl))
+    # print(set(spnl))
+    # print(concat.sp_acc_comb)
+    len_concat_id_dict = len(concat.sp_acc_comb)
 
 
-try:
     assert len_single == len_concat_id_dict
-    print("tests passed")
-except:
-    print("test fails")

--- a/tests/test_concat_select_rnd_seq.py
+++ b/tests/test_concat_select_rnd_seq.py
@@ -4,66 +4,62 @@ from physcraper.concat import Concat
 from physcraper import debug
 import sys
 
+def test():
+    workdir_its = "runs/tiny_comb_its"
+    workdir_ets = "runs/tiny_comb_ets"
+    email = "martha.kandziora@yahoo.com"
 
-workdir_its = "runs/tiny_comb_its"
-workdir_ets = "runs/tiny_comb_ets"
-email = "martha.kandziora@yahoo.com"
+    pickle_fn = "scrape_checkpoint.p"
 
-pickle_fn = "scrape_checkpoint.p"
+    workdir_comb = "tests/output/impl_concat"
+    genelist = {"its": {"workdir": workdir_its, "pickle": pickle_fn}, "ets": {"workdir": workdir_ets, "pickle": pickle_fn}}
 
-workdir_comb = "tests/output/impl_concat"
-genelist = {"its": {"workdir": workdir_its, "pickle": pickle_fn}, "ets": {"workdir": workdir_ets, "pickle": pickle_fn}}
+    # get to test status
 
-# get to test status
-
-sys.stdout.write("\ntests Concat func select_rnd_seq\n")
-
-
-concat = Concat(workdir_comb, email)
-for item in genelist.keys():
-    concat.load_single_genes(genelist[item]['workdir'], genelist[item]["pickle"], item)
+    sys.stdout.write("\ntests Concat func select_rnd_seq\n")
 
 
-concat.combine()
-concat.sp_seq_counter()
-sp_to_keep = concat.sp_to_keep()
-concat.get_largest_tre()
+    concat = Concat(workdir_comb, email)
+    for item in genelist.keys():
+        concat.load_single_genes(genelist[item]['workdir'], genelist[item]["pickle"], item)
 
 
-# print("test: select rnd seq")
-count = 2
-concat.tmp_dict = deepcopy(concat.sp_acc_comb)
-# print("while")
-# part of make_sp_gene_dict
+    concat.combine()
+    concat.sp_seq_counter()
+    sp_to_keep = concat.sp_to_keep()
+    concat.get_largest_tre()
 
-len_before = len(concat.comb_seq)
 
-while len(concat.tmp_dict.keys()) >= 1:
-    del_gi = {}
-    for spn in concat.tmp_dict.keys():
-        # print(spn)
-        sp_to_keep_list = sp_to_keep.keys()
-        # debug(sp_to_keep_list)
-        if spn.replace(" ", "_") in sp_to_keep_list:
-            tmp_gene = deepcopy(concat.genes_present)
-            for gene in concat.tmp_dict[spn]:
+    # print("test: select rnd seq")
+    count = 2
+    concat.tmp_dict = deepcopy(concat.sp_acc_comb)
+    # print("while")
+    # part of make_sp_gene_dict
 
-                tmp_gene.remove(gene)
-                # print("select_rnd_seq")
-                # print(spn, gene,del_gi, count)
-                del_gi = concat.select_rnd_seq(spn, gene, del_gi)
-                # print("now it should break")
+    len_before = len(concat.comb_seq)
+
+    while len(concat.tmp_dict.keys()) >= 1:
+        del_gi = {}
+        for spn in concat.tmp_dict.keys():
+            # print(spn)
+            sp_to_keep_list = sp_to_keep.keys()
+            # debug(sp_to_keep_list)
+            if spn.replace(" ", "_") in sp_to_keep_list:
+                tmp_gene = deepcopy(concat.genes_present)
+                for gene in concat.tmp_dict[spn]:
+
+                    tmp_gene.remove(gene)
+                    # print("select_rnd_seq")
+                    # print(spn, gene,del_gi, count)
+                    del_gi = concat.select_rnd_seq(spn, gene, del_gi)
+                    # print("now it should break")
+                    break
                 break
             break
         break
-    break
 
-len_after = len(concat.comb_seq[gene])
+    len_after = len(concat.comb_seq[gene])
 
-#
+    #
 
-try:
     assert len_before + 1 == len_after
-    print("tests passed")
-except:
-    print("test fails")

--- a/tests/test_concat_sp_to_keep.py
+++ b/tests/test_concat_sp_to_keep.py
@@ -10,36 +10,37 @@ pickle_fn = "scrape_checkpoint.p"
 workdir_comb = "tests/output/impl_concat"
 genelist = {"its": {"workdir": workdir_its, "pickle": pickle_fn}, "ets": {"workdir": workdir_ets, "pickle": pickle_fn}}
 
-# get to test status
+def test():
+    # get to test status
 
-concat = Concat(workdir_comb, email)
-for item in genelist.keys():
-    concat.load_single_genes(genelist[item]['workdir'], genelist[item]["pickle"], item)
+    concat = Concat(workdir_comb, email)
+    for item in genelist.keys():
+        concat.load_single_genes(genelist[item]['workdir'], genelist[item]["pickle"], item)
 
-concat.combine()
-concat.sp_seq_counter()
-sp_to_keep = concat.sp_to_keep()
+    concat.combine()
+    concat.sp_seq_counter()
+    sp_to_keep = concat.sp_to_keep()
 
-# print(sp_to_keep.keys())
-#
-# print("tests sp_to_keep")
+    # print(sp_to_keep.keys())
+    #
+    # print("tests sp_to_keep")
 
-counter = 0
-sp_keep = []
-for sp in concat.sp_counter:
-    for gene in concat.sp_counter[sp]:
-        if concat.sp_counter[sp][gene] == 0:
-            sp_keep.append(sp)
+    counter = 0
+    sp_keep = []
+    for sp in concat.sp_counter:
+        for gene in concat.sp_counter[sp]:
+            if concat.sp_counter[sp][gene] == 0:
+                sp_keep.append(sp)
 
-# print(sp_keep)
-# print(sp_to_keep.keys())
-# print(len(sp_keep))
-#
-print(len(sp_to_keep.keys()))
+    # print(sp_keep)
+    # print(sp_to_keep.keys())
+    # print(len(sp_keep))
+    #
+    print(len(sp_to_keep.keys()))
 
-try:
-    assert set(sp_to_keep.keys()) == set(sp_keep)
-    print("tests passed")
-except:
-    print("test fails")
+    try:
+        assert set(sp_to_keep.keys()) == set(sp_keep)
+        print("tests passed")
+    except:
+        print("test fails")
 

--- a/tests/test_concat_spcounter.py
+++ b/tests/test_concat_spcounter.py
@@ -14,28 +14,24 @@ genelist = {"its": {"workdir": workdir_its, "pickle": pickle_fn}, "ets": {"workd
 
 sys.stdout.write("\ntests Concat func sp_counter\n")
 
+def test():
+    concat = Concat(workdir_comb, email)
+    for item in genelist.keys():
+        concat.load_single_genes(genelist[item]["workdir"], genelist[item]["pickle"], item)
 
-concat = Concat(workdir_comb, email)
-for item in genelist.keys():
-    concat.load_single_genes(genelist[item]["workdir"], genelist[item]["pickle"], item)
+    concat.combine()
+    concat.sp_seq_counter()
 
-concat.combine()
-concat.sp_seq_counter()
+    # print("tests if nothing gets lost from loading single runs to make sp_counter")
 
-# print("tests if nothing gets lost from loading single runs to make sp_counter")
+    counter = 0
+    for sp in concat.sp_counter:
+        for gene in concat.sp_counter[sp]:
+            counter += concat.sp_counter[sp][gene]
+    # print(counter)
 
-counter = 0
-for sp in concat.sp_counter:
-    for gene in concat.sp_counter[sp]:
-        counter += concat.sp_counter[sp][gene]
-# print(counter)
+    single_run_items = 0
+    for item in concat.single_runs:
+        single_run_items += (len(concat.single_runs[item].data.aln.taxon_namespace))
 
-single_run_items = 0
-for item in concat.single_runs:
-    single_run_items += (len(concat.single_runs[item].data.aln.taxon_namespace))
-
-try:
     assert counter == single_run_items
-    print("tests passed")
-except:
-    print("test fails")

--- a/tests/test_tiny_standard.py
+++ b/tests/test_tiny_standard.py
@@ -2,6 +2,7 @@
 import os
 import json
 from physcraper import wrappers
+from physcraper import ConfigObj, IdDicts, OtuJsonDict
 
 
 
@@ -19,27 +20,27 @@ otu_jsonfi = "{}/otu_dict.json".format(workdir)
 
 # setting up a physcraper run
 
+def test():
+    if not os.path.exists("{}".format(workdir)):
+            os.makedirs("{}".format(workdir))
 
-if not os.path.exists("{}".format(workdir)):
-        os.makedirs("{}".format(workdir))
-
-conf = ConfigObj(configfi, interactive=False)
-ids = IdDicts(conf, workdir=workdir)
-
-
-if os.path.exists(otu_jsonfi):
-    print("load json")
-    otu_json = json.load(open(otu_jsonfi))
-else:
-    otu_json = OtuJsonDict(id_to_spn, ids)
-    json.dump(otu_json, open(otu_jsonfi,"w"))
+    conf = ConfigObj(configfi, interactive=False)
+    ids = IdDicts(conf, workdir=workdir)
 
 
-# that's the main function
-wrappers.own_data_run(seqaln,
-                 mattype,
-                 trfn,
-                 schema_trf,
-                 workdir,
-                 otu_jsonfi,
-                 configfi)
+    if os.path.exists(otu_jsonfi):
+        print("load json")
+        otu_json = json.load(open(otu_jsonfi))
+    else:
+        otu_json = OtuJsonDict(id_to_spn, ids)
+        json.dump(otu_json, open(otu_jsonfi,"w"))
+
+
+    # that's the main function
+    wrappers.own_data_run(seqaln,
+                     mattype,
+                     trfn,
+                     schema_trf,
+                     workdir,
+                     otu_jsonfi,
+                     configfi)

--- a/tests/test_unmapped_taxa.py
+++ b/tests/test_unmapped_taxa.py
@@ -14,51 +14,50 @@ absworkdir = os.path.abspath(workdir)
 
 configfi = "tests/data/test.config"
 
-# try:
+def test_0():
+    if os.path.isfile("tests/data/precooked/otol_scraper.p"):
+        # physcraper.debug(os.getcwd())
+        conf = physcraper.ConfigObj(configfi, interactive=False)
+        # physcraper.debug("conf")
+        conf.unmapped = 'keep'
+        # physcraper.debug("set unmapped")
+        data_obj = pickle.load(open("tests/data/precooked/otol_tiny_dataobj.p", 'rb'))
+        data_obj.workdir = absworkdir
+        # physcraper.debug("dataobj loaded")
+        ids = physcraper.IdDicts(conf, workdir=data_obj.workdir)
+        ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/otol_tiny_gi_map.p", "rb"))
+        # physcraper.debug("ids loaded")
+        scraper = pickle.load(open("tests/data/precooked/otol_scraper.p", "rb"))
+        # physcraper.debug("scraper loaded")
+        # scraper2 = pickle.load(open("tests/data/precooked/otol_scraper.p", "rb"))
+        num_keep = len(scraper.data.aln.taxon_namespace)
+        # physcraper.debug('num_keep')
 
-if os.path.isfile("tests/data/precooked/otol_scraper.p"):
-    # physcraper.debug(os.getcwd())
-    conf = physcraper.ConfigObj(configfi, interactive=False)
-    # physcraper.debug("conf")
-    conf.unmapped = 'keep'
-    # physcraper.debug("set unmapped")
-    data_obj = pickle.load(open("tests/data/precooked/otol_tiny_dataobj.p", 'rb'))
-    data_obj.workdir = absworkdir
-    # physcraper.debug("dataobj loaded")
-    ids = physcraper.IdDicts(conf, workdir=data_obj.workdir)
-    ids.acc_ncbi_dict = pickle.load(open("tests/data/precooked/otol_tiny_gi_map.p", "rb"))
-    # physcraper.debug("ids loaded")
-    scraper = pickle.load(open("tests/data/precooked/otol_scraper.p", "rb"))
-    # physcraper.debug("scraper loaded")
-    # scraper2 = pickle.load(open("tests/data/precooked/otol_scraper.p", "rb"))
-    num_keep = len(scraper.data.aln.taxon_namespace)
-    # physcraper.debug('num_keep')
-
-    # physcraper.debug(num_keep)
-# except:
-else:
-    sys.stdout.write("\n\n No files present\n\n")
-    conf = physcraper.ConfigObj(configfi)
-    conf.unmapped = 'keep'
-    aln = DnaCharacterMatrix.get(path=seqaln, schema=mattype)
-    data_obj = physcraper.generate_ATT_from_phylesystem(aln=aln,
-                                 workdir=workdir,
-                                 study_id = study_id,
-                                 tree_id = tree_id,
-                                 phylesystem_loc = conf.phylesystem_loc)
-    # physcraper.debug(len(data_obj.aln.taxon_namespace))
-    pickle.dump(data_obj, open("tests/data/precooked/otol_tiny_dataobj.p", "wb" ))
-    ids =  physcraper.IdDicts(conf, workdir=workdir)
-    # physcraper.debug(os.getcwd())
-    pickle.dump(ids.acc_ncbi_dict, open("tests/data/precooked/otol_tiny_gi_map.p", "wb"))
-    data_obj.write_files()
-    scraper = physcraper.PhyscraperScrape(data_obj, ids)
-    # physcraper.debug(len(scraper.data.aln.taxon_namespace))
-    # physcraper.debug("scraper obj made")
-    pickle.dump(scraper.config, open("tests/data/precooked/otol_conf.p", "wb"))
-    pickle.dump(scraper, open("tests/data/precooked/otol_scraper.p", "wb"))
-    num_keep = len(scraper.data.aln.taxon_namespace)
-    # physcraper.debug(num_keep)
+        # physcraper.debug(num_keep)
+    # except:
+    else:
+        sys.stdout.write("\n\n No files present\n\n")
+        conf = physcraper.ConfigObj(configfi)
+        conf.unmapped = 'keep'
+        aln = DnaCharacterMatrix.get(path=seqaln, schema=mattype)
+        data_obj = physcraper.generate_ATT_from_phylesystem(aln=aln,
+                                    workdir=workdir,
+                                    study_id = study_id,
+                                    tree_id = tree_id,
+                                    phylesystem_loc = conf.phylesystem_loc)
+        # physcraper.debug(len(data_obj.aln.taxon_namespace))
+        pickle.dump(data_obj, open("tests/data/precooked/otol_tiny_dataobj.p", "wb" ))
+        ids =  physcraper.IdDicts(conf, workdir=workdir)
+        # physcraper.debug(os.getcwd())
+        pickle.dump(ids.acc_ncbi_dict, open("tests/data/precooked/otol_tiny_gi_map.p", "wb"))
+        data_obj.write_files()
+        scraper = physcraper.PhyscraperScrape(data_obj, ids)
+        # physcraper.debug(len(scraper.data.aln.taxon_namespace))
+        # physcraper.debug("scraper obj made")
+        pickle.dump(scraper.config, open("tests/data/precooked/otol_conf.p", "wb"))
+        pickle.dump(scraper, open("tests/data/precooked/otol_scraper.p", "wb"))
+        num_keep = len(scraper.data.aln.taxon_namespace)
+        # physcraper.debug(num_keep)
 
 
 

--- a/tests/tiny_filter_ownfile_remote.py
+++ b/tests/tiny_filter_ownfile_remote.py
@@ -3,48 +3,49 @@ import os
 import json
 from physcraper import wrappers, OtuJsonDict, ConfigObj, IdDicts
 
-# define here your files
-seqaln = "tests/data/tiny_test_example/test.fas"
-mattype = "fasta"
-trfn = "tests/data/tiny_test_example/test.tre"
-schema_trf = "newick"
-id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
-workdir = "tests/output/tiny_filter_own2"
-configfi = "tests/data/remote.config"
-otu_jsonfi = "{}/otu_dict.json".format(workdir)
+def test():
+    # define here your files
+    seqaln = "tests/data/tiny_test_example/test.fas"
+    mattype = "fasta"
+    trfn = "tests/data/tiny_test_example/test.tre"
+    schema_trf = "newick"
+    id_to_spn = r"tests/data/tiny_test_example/test_nicespl.csv"
+    workdir = "tests/output/tiny_filter_own2"
+    configfi = "tests/data/remote.config"
+    otu_jsonfi = "{}/otu_dict.json".format(workdir)
 
-# change to your filtering criteria
-threshold = 2
-selectby = "blast"
-downtorank = "species"
-ingroup_mrca = 723076
-
-
-# setup the run
-if not os.path.exists("{}".format(workdir)):
-        os.makedirs("{}".format(workdir))
-
-conf = ConfigObj(configfi)
-ids = IdDicts(conf, workdir=workdir)
-
-if os.path.exists(otu_jsonfi):
-    print("load json")
-    otu_json = json.load(open(otu_jsonfi))
-else:
-    otu_json = OtuJsonDict(id_to_spn, ids)
-    json.dump(otu_json, open(otu_jsonfi, "w"))
+    # change to your filtering criteria
+    threshold = 2
+    selectby = "blast"
+    downtorank = "species"
+    ingroup_mrca = 723076
 
 
-# select a wrapper function, depending on what you want to do, see short tutorial:
-wrappers.filter_data_run(seqaln,
-                         mattype,
-                         trfn,
-                         schema_trf,
-                         workdir,
-                         threshold,
-                         otu_jsonfi,
-                         configfi,
-                         selectby=selectby,
-                         downtorank=downtorank,
-                         ingroup_mrca=ingroup_mrca)
+    # setup the run
+    if not os.path.exists("{}".format(workdir)):
+            os.makedirs("{}".format(workdir))
+
+    conf = ConfigObj(configfi)
+    ids = IdDicts(conf, workdir=workdir)
+
+    if os.path.exists(otu_jsonfi):
+        print("load json")
+        otu_json = json.load(open(otu_jsonfi))
+    else:
+        otu_json = OtuJsonDict(id_to_spn, ids)
+        json.dump(otu_json, open(otu_jsonfi, "w"))
+
+
+    # select a wrapper function, depending on what you want to do, see short tutorial:
+    wrappers.filter_data_run(seqaln,
+                             mattype,
+                             trfn,
+                             schema_trf,
+                             workdir,
+                             threshold,
+                             otu_jsonfi,
+                             configfi,
+                             selectby=selectby,
+                             downtorank=downtorank,
+                             ingroup_mrca=ingroup_mrca)
 


### PR DESCRIPTION
This does two things:

1) wrap all the test in function because py.test like functions. This allow to separate two steps: test-discovery and test running. Basically py.test first scan/import all the files, and then run each test. 
That later should allow to gather statistics or group test like "slow" test, test that require blast...etc. and ask pytest to run only those. 

2) setup a minimal travis script that only discover test (running does not work yet).

That should basically give a sanity check that syntax is correct and most files can be imported. 

We can later enable test one by one, and refactor to use conda on travis (to get things like raxml, because it is package for conda)