### PR TITLE
Fix some easy-install issues.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python
 
-from setuptools import setup
+from distutils.core import setup
 
 setup(name='Physcraper',
       version='0.0',


### PR DESCRIPTION
When doing multiple dev-install in a row, setuptools's setup() function
can add some weirdness.

As far as I understand this should make installing both physcraper and
peyotl from a git branch a tiny bit more robust.

If I'm right the issue is due to peyotl using ez_setup/easy_install,
which are both deprecated.

--

I'll  keep trying to see if I can make the install more robust