### PR TITLE
Example Crosslink documentation with Dendropy.

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -202,4 +202,5 @@ epub_exclude_files = ['search.html']
 # -- Options for intersphinx extension ---------------------------------------
 
 # Example configuration for intersphinx: refer to the Python standard library.
-intersphinx_mapping = {'https://docs.python.org/': None}
+intersphinx_mapping = {'py': ('https://docs.python.org/',None),
+                       'dp': ('https://dendropy.org/', None)}

--- a/physcraper/__init__.py
+++ b/physcraper/__init__.py
@@ -564,7 +564,7 @@ class AlignTreeTax(object):
 
           * **newick**: dendropy.tre.as_string(schema=schema_trf) object
           * **otu_dict**: json file including the otu_dict information generated earlier
-          * **alignment**: dendropy DNACharacterMatrix object
+          * **alignment**: dendropy :class:`DnaCharacterMatrix <dendropy.datamodel.charmatrixmodel.DnaCharacterMatrix>` object
           * **ingroup_mrca**: OToL identifier of the group of interest, either subclade as defined by user or of all tiplabels in the phylogeny
           * **workdir**: the path to the corresponding working directory
           * **schema**: optional argument to define tre file schema, if different from "newick"


### PR DESCRIPTION
This show the basic on how sphinx can be used to crosslink
documentation. Here it's a bit verbose, but usually something like

     :any:`DnaCharacterMatrix` 

Should be sufficient to crosslink once the inventory are set.
Once the documentation is built, you should be able to see that the
`DnaCharacterMatrix` item in the rendered doc is a link to dendropy
documentation