### PR TITLE
Install m2r only on "recent enough" python.

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -22,5 +22,5 @@ numpy==1.14.5
 ete2==2.3.10
 pandas==0.23.4
 pytest
-m2r
+m2r; python_version > '2.7.13'
 recommonmark


### PR DESCRIPTION
It's ok as it's only needed for documentation