### PR TITLE
Example of pytest configuration that mark tests as slow.

### DIFF
--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -1,0 +1,21 @@
+import pytest
+
+
+def pytest_addoption(parser):
+    parser.addoption(
+        "--runslow", action="store_true", default=False, help="run slow tests"
+    )
+
+
+def pytest_collection_modifyitems(config, items):
+    if config.getoption("--runslow"):
+        # --runslow given in cli: do not skip slow tests
+        return
+    skip_slow = pytest.mark.skip(reason="need --runslow option to run")
+    # skip_test = pytest.mark.skip(reason="skip all for now")
+    for item in items:
+        if "slow" in item.keywords:
+            item.add_marker(skip_slow)
+        #elif "fast" not in item.keywords:
+        #    item.add_marker(skip_test)
+

--- a/tests/test_blacklist.py
+++ b/tests/test_blacklist.py
@@ -6,7 +6,13 @@ from physcraper import ConfigObj, IdDicts, FilterBlast, debug
 
 sys.stdout.write("\ntests blacklist\n")
 
+from pytest import mark
 
+# you can actually do whatever
+# ruftrum = mark.ruftrum will work and create a "ruftrum" test. 
+slow = mark.slow
+
+@slow
 def test_blacklist():
 
     workdir = "tests/output/test_blacklist"


### PR DESCRIPTION
Slow test are not going to be ran by default.
We could also (see commented) mark all test as slow by default,
and only mark the fast ones with a `@fast`.

We can create arbitrary tag as well, or could read an external file.

-- 
This is relatively new and simple to do than what I remembered. 