### PR TITLE
replace some chdir

### DIFF
--- a/physcraper/__init__.py
+++ b/physcraper/__init__.py
@@ -2474,9 +2474,11 @@ class PhyscraperScrape(object):
                 count = count + 1
                 seq = seq_l[i]
                 local_blast.write_filterblast_files(self.workdir, key, seq, db=True, fn="local_unpubl_seq")
+        old_cwd = os.getcwd()
         os.chdir(os.path.join(self.workdir, "blast"))
         cmd1 = "makeblastdb -in {}_db -dbtype nucl".format("local_unpubl_seq")
         os.system(cmd1)
+        os.chdir(old_cwd)
 
 
 class FilterBlast(PhyscraperScrape):


### PR DESCRIPTION
In many cases instead of updating the cwd of the process we can just
pass in which cwd we want to run a given command. This appear to be a
bit cleaner.

There are some small distinction between subprocess.call and os.system,
the former is prefered. The `shell=True` parameter will do the argument
parsing in the subshell. We could also contruct the args manually and
not pass shell=True. That would be preferable in particular if file
names could have spaces in them.