### PR TITLE
Run tests in parallel and collect coverage informations.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,7 @@ before_install:
   - conda create -q -n test-environment python=$TRAVIS_PYTHON_VERSION
   - source activate test-environment
   - conda install -c bioconda raxml
+  - pip install pytest-cov codecov pytest-xdist
   - python setup.py install
 
   #### ete fails now, because of conda

--- a/pytest.ini
+++ b/pytest.ini
@@ -5,7 +5,7 @@ env =
 	HOME=~/home/blubb/Documents/gitdata
 
 # will stop running after two test failures
-addopts = --maxfail=2 -rf
+addopts = --maxfail=2 -rf --durations=0 --num auto -v
 
 # custom flags to group tests?
 markers =

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,8 +5,7 @@ argcomplete==1.6.0
 argparse==1.2.1
 biopython==1.68
 configparser==3.5.0
-coverage==4.2
-enum34==1.1.6
+coverage>=4.4
 locket==0.2.0
 -e git+https://github.com/OpenTreeOfLife/peyotl@api_v3#egg=peyotl
 python-dateutil==2.6.0

--- a/tests/run_tests.sh
+++ b/tests/run_tests.sh
@@ -1,27 +1,28 @@
 if [ -f output/owndata/ ]; then echo 'Found some!'; fi
 
 #py.test --cov=physcraper tests/test_remove_identical_seqs.py
-py.test tests/test_remove_identical_seqs.py
-py.test tests/test_fromfile.py
-py.test tests/test_configread.py
-py.test tests/test_species_translation.py
-py.test tests/test_write_labelled.py
-py.test tests/test_add_all.py
-py.test tests/test_loop_for_blast.py
-py.test tests/test_prune_short.py
-py.test tests/test_remove_taxa_aln_tre.py
-py.test tests/test_run_local_blast.py
-py.test tests/test_sp_d.py
-py.test tests/test_sp_seq_d.py
-py.test tests/test_select_seq_by_local_blast.py
-py.test tests/test_calc_mean_sd.py
-py.test tests/test_read_local_blast.py
-py.test tests/tests_write_blast.py
-py.test tests/test_remove_id_seq.py
-py.test tests/test_addLocal.py
-py.test tests/test_reconcile.py
-py.test tests/test_trim.py
-py.test tests/test_unmapped_taxa.py
+py.test  --cov=physcraper --runslow -v \
+ tests/test_remove_identical_seqs.py \
+ tests/test_fromfile.py \
+ tests/test_configread.py \
+ tests/test_species_translation.py \
+ tests/test_write_labelled.py \
+ tests/test_add_all.py \
+ tests/test_loop_for_blast.py \
+ tests/test_prune_short.py \
+ tests/test_remove_taxa_aln_tre.py \
+ tests/test_run_local_blast.py \
+ tests/test_sp_d.py \
+ tests/test_sp_seq_d.py \
+ tests/test_select_seq_by_local_blast.py \
+ tests/test_calc_mean_sd.py \
+ tests/test_read_local_blast.py \
+ tests/tests_write_blast.py \
+ tests/test_remove_id_seq.py \
+ tests/test_addLocal.py \
+ tests/test_reconcile.py \
+ tests/test_trim.py \
+ tests/test_unmapped_taxa.py
 #python tests/test_trim2.py
 
 py.test tests/test_blacklist.py


### PR DESCRIPTION
This speeds up test by running them in parallel (including slow test on
my machine this takes ~3 minutes).

It also start collecting coverage information so that we can upload them
to codecov later and show the duration on each test.

So far we autodetect the number of cores to run the test so it should
also speed travis ci that gives us 2 cores.